### PR TITLE
Attempting to slow down the bot

### DIFF
--- a/app/src/index.ts
+++ b/app/src/index.ts
@@ -13,6 +13,7 @@ import winston from "winston";
 import TXManager from "./TxManager";
 
 dotenv.config();
+const POLLING_INTERVAL = 60_000;
 const OPTIMISM_ALCHEMY_URL = `wss://opt-mainnet.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY!}`;
 const SLACK_WEBHOOK_URL = `https://hooks.slack.com/services/${process.env.SLACK_WEBHOOK0!}/${process.env.SLACK_WEBHOOK1!}/${process.env.SLACK_WEBHOOK2!}`;
 const port = process.env.PORT || 8080;
@@ -171,7 +172,7 @@ collect_borrowers(ALOE_INITIAL_DEPLOY, borrowers);
 const pollingInterval = setInterval(() => {
     console.log("Scanning borrowers...");
     scan(borrowers);
-}, 20_000);
+}, POLLING_INTERVAL);
 
 winston.log("info", `🔋 Powering up liquidation bot #${uniqueId}`);
 


### PR DESCRIPTION
Currently, the bot is burning through alchemy compute units faster than we anticipated, so we are slowing the bot down a bit to preserve some of those compute units. This should not have a negative impact on the bot's ability to liquidate, although it would make it less competitive; since there are currently no other liquidators, this is not a problem.