### PR TITLE
Incrementing strain on retry

### DIFF
--- a/app/src/Liquidator.ts
+++ b/app/src/Liquidator.ts
@@ -3,17 +3,18 @@ import { Log } from "web3-core";
 import { Contract } from "web3-eth-contract";
 import { AbiItem } from "web3-utils";
 import LiquidatorABIJson from "./abis/Liquidator.json";
+import MarginAccountABIJson from "./abis/MarginAccount.json";
 import TxManager from "./TxManager";
 import winston from "winston";
 import Bottleneck from "bottleneck";
 
-export const MAX_STRAIN = 10;
-export const MIN_STRAIN = 1;
+const ALOE_HEALTHY_ERROR_MESSAGE = "Aloe: healthy";
+const ALOE_GRACE_ERROR_MESSAGE = "Aloe: grace";
 const FACTORY_ADDRESS: string = process.env.FACTORY_ADDRESS!;
 const CREATE_ACCOUNT_TOPIC_ID: string = process.env.CREATE_ACCOUNT_TOPIC_ID!;
 const WALLET_ADDRESS = process.env.WALLET_ADDRESS!;
 const ALOE_INITIAL_DEPLOY = 0;
-const POLLING_INTERVAL_MS = 60_000;
+const POLLING_INTERVAL_MS = 60_000; // 2.5 minutes
 const CLIENT_KEEPALIVE_INTERVAL_MS = 60_000;
 const RECONNECT_DELAY_MS = 5_000;
 const RECONNECT_MAX_ATTEMPTS = 5;
@@ -26,7 +27,22 @@ export type HealthCheckResponse = {
   message: string;
 };
 
+enum LiquidationError {
+  Healthy = "healthy",
+  Grace = "grace",
+  Unknown = "unknown",
+}
+
+type EstimateGasLiquidationResult = {
+  success: boolean;
+  estimatedGas: number;
+  error?: LiquidationError;
+  errorMsg?: string;
+};
+
 export default class Liquidator {
+  public static readonly MAX_STRAIN = 10;
+  public static readonly MIN_STRAIN = 1;
   public static readonly GAS_LIMIT = 3_000_000;
   private pollingInterval: NodeJS.Timer | null;
   private web3: Web3;
@@ -65,7 +81,7 @@ export default class Liquidator {
     this.web3.eth.handleRevert = true;
     this.liquidatorContract = new this.web3.eth.Contract(
       LiquidatorABIJson as AbiItem[],
-      liquidatorAddress,
+      liquidatorAddress
     );
     this.txManager = new TxManager(this.web3, this.liquidatorContract);
     this.borrowers = [];
@@ -213,45 +229,78 @@ export default class Liquidator {
 
   async isSolvent(borrower: string): Promise<boolean> {
     const shortName = borrower.slice(0, 8);
-    try {
-      winston.log(
-        "debug",
-        `Checking solvency of ${shortName} via gas estimation...`
-      );
-
-      const data = this.web3.eth.abi.encodeParameter("address", WALLET_ADDRESS);
-      console.log(
-        "Checking solvency of",
-        borrower,
-        "via gas estimation...",
-        data
-      );
-      const estimatedGasLimit: number = await this.liquidatorContract.methods
-        .liquidate(borrower, data, MIN_STRAIN)
-        .estimateGas({
-          gasLimit: Liquidator.GAS_LIMIT,
-        });
-
-      winston.log(
-        "debug",
-        `--> Received estimate (${estimatedGasLimit} gas), indicating that ${shortName} can be liquidated`
-      );
+    winston.log(
+      "debug",
+      `Checking solvency of ${shortName} via gas estimation...`
+    );
+    const estimatedGasResult: EstimateGasLiquidationResult =
+      await this.estimateGasForLiquidation(borrower, Liquidator.MAX_STRAIN);
+    if (estimatedGasResult.success) {
       return false;
-    } catch (e) {
-      const msg = (e as Error).message;
-
-      if (msg.includes("Aloe: healthy")) {
-        winston.log("debug", `--> ${shortName} is healthy`);
-      } else {
-        console.log(
-          "WARNING: Received estimation error other than 'Aloe: healthy'",
-          msg
+    } else if (estimatedGasResult.error === LiquidationError.Healthy) {
+      return true;
+    } else if (estimatedGasResult.error === LiquidationError.Grace) {
+      winston.log("info", `⏳ ${shortName} is in grace period`);
+      return true;
+    } else {
+      // Checking the unleashLiquidationTime is a workaround for a none-critical bug.
+      const borrowerContract = new this.web3.eth.Contract(
+        MarginAccountABIJson as AbiItem[],
+        borrower
+      );
+      const slot0 = await borrowerContract.methods.slot0().call();
+      const unleashLiquidationTime = slot0.unleashLiquidationTime;
+      if (unleashLiquidationTime === "0") {
+        winston.log(
+          "error",
+          `🚨 ${shortName} is not healthy, but has an unleashLiquidationTime of 0. This is not expected. Error encountered: ${estimatedGasResult.errorMsg}.`
         );
-        console.log(
-          "This most likely means that we just warned them and we are waiting to actually liquidate them."
+      } else {
+        winston.log(
+          "debug",
+          `🚨 ${shortName} is not healthy, but has an unleashLiquidationTime of ${unleashLiquidationTime}. This is likely a result of the bug with repay/modify.`
         );
       }
       return true;
+    }
+  }
+
+  private async estimateGasForLiquidation(
+    borrower: string,
+    strain: number
+  ): Promise<EstimateGasLiquidationResult> {
+    const integerStrain = Math.floor(strain);
+    if (
+      integerStrain < Liquidator.MIN_STRAIN ||
+      integerStrain > Liquidator.MAX_STRAIN
+    ) {
+      throw new Error(`Invalid strain: ${strain}`);
+    }
+    const data = this.web3.eth.abi.encodeParameter("address", WALLET_ADDRESS);
+    try {
+      const estimatedGasLimit: number = await this.liquidatorContract.methods
+        .liquidate(borrower, data, integerStrain)
+        .estimateGas({
+          gasLimit: Liquidator.GAS_LIMIT,
+        });
+      return {
+        success: true,
+        estimatedGas: estimatedGasLimit,
+      };
+    } catch (e) {
+      const errorMsg = (e as Error).message;
+      let errorType: LiquidationError = LiquidationError.Unknown;
+      if (errorMsg.includes(ALOE_HEALTHY_ERROR_MESSAGE)) {
+        errorType = LiquidationError.Healthy;
+      } else if (errorMsg.includes(ALOE_GRACE_ERROR_MESSAGE)) {
+        errorType = LiquidationError.Grace;
+      }
+      return {
+        success: false,
+        estimatedGas: 0,
+        error: errorType,
+        errorMsg,
+      };
     }
   }
 

--- a/app/src/Liquidator.ts
+++ b/app/src/Liquidator.ts
@@ -7,6 +7,8 @@ import TxManager from "./TxManager";
 import winston from "winston";
 import Bottleneck from "bottleneck";
 
+export const MAX_STRAIN = 10;
+export const MIN_STRAIN = 1;
 const FACTORY_ADDRESS: string = process.env.FACTORY_ADDRESS!;
 const CREATE_ACCOUNT_TOPIC_ID: string = process.env.CREATE_ACCOUNT_TOPIC_ID!;
 const WALLET_ADDRESS = process.env.WALLET_ADDRESS!;
@@ -225,7 +227,7 @@ export default class Liquidator {
         data
       );
       const estimatedGasLimit: number = await this.liquidatorContract.methods
-        .liquidate(borrower, data, 1)
+        .liquidate(borrower, data, MIN_STRAIN)
         .estimateGas({
           gasLimit: Liquidator.GAS_LIMIT,
         });

--- a/app/src/TxManager.ts
+++ b/app/src/TxManager.ts
@@ -5,13 +5,13 @@ import { log } from "winston";
 import { TransactionConfig, TransactionReceipt } from "web3-eth";
 import { Contract } from "web3-eth-contract";
 import { Account } from "web3-core";
-import Liquidator, { MAX_STRAIN, MIN_STRAIN } from "./Liquidator";
+import Liquidator from "./Liquidator";
 
 config();
 
 const MAX_RETRIES_ALLOWED: number = 10;
 const GAS_INCREASE_FACTOR: number = 1.10;
-const MAX_ACCEPTABLE_ERRORS = 1;
+const MAX_ACCEPTABLE_ERRORS = 10;
 const WALLET_ADDRESS = process.env.WALLET_ADDRESS!;
 
 type LiquidationTxInfo = {
@@ -89,7 +89,7 @@ export default class TXManager {
                     gasPrice: Math.min(parseInt(currentGasPrice), parseInt(this.gasPriceMaximum)).toString(),
                     timeSent: new Date().getTime(),
                     retries: 0,
-                    currentStrain: MIN_STRAIN,
+                    currentStrain: Liquidator.MIN_STRAIN,
                 }
                 this.pendingTransactions.set(borrower, liquidationTxInfo);
             } else {
@@ -101,7 +101,7 @@ export default class TXManager {
                 }
 
                 liquidationTxInfo.retries++;
-                liquidationTxInfo.currentStrain = Math.min(liquidationTxInfo.currentStrain + 1, MAX_STRAIN);
+                liquidationTxInfo.currentStrain = Math.min(liquidationTxInfo.currentStrain + 1, Liquidator.MAX_STRAIN);
                 liquidationTxInfo.timeSent = new Date().getTime();
             }
             if (liquidationTxInfo.retries > MAX_RETRIES_ALLOWED) {

--- a/app/src/TxManager.ts
+++ b/app/src/TxManager.ts
@@ -5,11 +5,11 @@ import { log } from "winston";
 import { TransactionConfig, TransactionReceipt } from "web3-eth";
 import { Contract } from "web3-eth-contract";
 import { Account } from "web3-core";
-import Liquidator from "./Liquidator";
+import Liquidator, { MAX_STRAIN, MIN_STRAIN } from "./Liquidator";
 
 config();
 
-const MAX_RETRIES_ALLOWED: number = 5;
+const MAX_RETRIES_ALLOWED: number = 10;
 const GAS_INCREASE_FACTOR: number = 1.10;
 const MAX_ACCEPTABLE_ERRORS = 1;
 const WALLET_ADDRESS = process.env.WALLET_ADDRESS!;
@@ -19,6 +19,7 @@ type LiquidationTxInfo = {
     gasPrice: string;
     timeSent: number;
     retries: number;
+    currentStrain: number;
 }
 
 const MAX_GAS_PRICE_FOR_CHAIN: Map<number, string> = new Map<number, string>([
@@ -88,6 +89,7 @@ export default class TXManager {
                     gasPrice: Math.min(parseInt(currentGasPrice), parseInt(this.gasPriceMaximum)).toString(),
                     timeSent: new Date().getTime(),
                     retries: 0,
+                    currentStrain: MIN_STRAIN,
                 }
                 this.pendingTransactions.set(borrower, liquidationTxInfo);
             } else {
@@ -98,26 +100,27 @@ export default class TXManager {
                     liquidationTxInfo.gasPrice = newGasPrice.toString();
                 }
 
-                liquidationTxInfo["retries"]++;
-                liquidationTxInfo["timeSent"] = new Date().getTime();
+                liquidationTxInfo.retries++;
+                liquidationTxInfo.currentStrain = Math.min(liquidationTxInfo.currentStrain + 1, MAX_STRAIN);
+                liquidationTxInfo.timeSent = new Date().getTime();
             }
-            if (liquidationTxInfo["retries"] > MAX_RETRIES_ALLOWED) {
+            if (liquidationTxInfo.retries > MAX_RETRIES_ALLOWED) {
                 log("debug", `Exceeded maximum amount of retries when attempting to liquidate borrower: ${borrower}`);
                 continue;
             }
             const encodedAddress = this.client.eth.abi.encodeParameter("address", WALLET_ADDRESS);
             const currentNonce = await this.client.eth.getTransactionCount(WALLET_ADDRESS, "pending");
             const estimatedGasLimit: number = await this.liquidatorContract.methods
-                .liquidate(borrower, encodedAddress, 1)
+                .liquidate(borrower, encodedAddress, liquidationTxInfo.currentStrain)
                 .estimateGas({
                     gasLimit: Liquidator.GAS_LIMIT,
                 });
             const updatedGasLimit = Math.ceil(estimatedGasLimit * GAS_INCREASE_FACTOR);
-            const encodedData = this.liquidatorContract.methods.liquidate(borrower, encodedAddress, 1).encodeABI();
+            const encodedData = this.liquidatorContract.methods.liquidate(borrower, encodedAddress, liquidationTxInfo.currentStrain).encodeABI();
             const transactionConfig: TransactionConfig = {
                 from: WALLET_ADDRESS,
                 to: this.liquidatorContract.options.address,
-                gasPrice: liquidationTxInfo["gasPrice"],
+                gasPrice: liquidationTxInfo.gasPrice,
                 gas: updatedGasLimit,
                 nonce: currentNonce,
                 data: encodedData,


### PR DESCRIPTION
Increasing the strain increases our ability to liquidate difficult-to-liquidate individuals. We now check if a borrower is liquidatable using the MAX_STRAIN to ensure we check the worst-case scenario. I also updated the polling interval to every two and a half minutes to reduce our alchemy requests. Checking the `unleashLiquidationTime`in the case of an unknown revert reason gives us insight into whether the account is healthy and is merely a non-crucial bug or something else. I also added an estimateGasForLiquidation function to abstract the logic further and make the code more readable.