### PR TITLE
Add foundry/anvil harness for simulating and testing

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -4,7 +4,7 @@
   "main": "index.ts",
   "license": "MIT",
   "engines": {
-    "node": "16.x.x",
+    "node": "18.x.x",
     "yarn": ">=1.0.0 <2.0.0"
   },
   "devDependencies": {
@@ -15,7 +15,8 @@
     "build": "npx tsc",
     "gcp-build": "npx tsc",
     "start": "node lib/index.js",
-    "clean": "rm -rf lib"
+    "clean": "rm -rf lib",
+    "sim": "node lib/index-sim.js"
   },
   "dependencies": {
     "@types/big.js": "^6.1.2",

--- a/app/src/Liquidator.ts
+++ b/app/src/Liquidator.ts
@@ -10,7 +10,6 @@ import Bottleneck from "bottleneck";
 
 const FACTORY_ADDRESS: string = process.env.FACTORY_ADDRESS!;
 const CREATE_ACCOUNT_TOPIC_ID: string = process.env.CREATE_ACCOUNT_TOPIC_ID!;
-const WALLET_ADDRESS = process.env.WALLET_ADDRESS!;
 const ALOE_INITIAL_DEPLOY = 0;
 const POLLING_INTERVAL_MS = 150_000; // 2.5 minutes
 const CLIENT_KEEPALIVE_INTERVAL_MS = 60_000;
@@ -274,7 +273,7 @@ export default class Liquidator {
     ) {
       throw new Error(`Invalid strain: ${strain}`);
     }
-    const data = this.web3.eth.abi.encodeParameter("address", WALLET_ADDRESS);
+    const data = this.web3.eth.abi.encodeParameter("address", this.txManager.address());
     try {
       const estimatedGasLimit: number = await this.liquidatorContract.methods
         .liquidate(borrower, data, integerStrain)

--- a/app/src/Liquidator.ts
+++ b/app/src/Liquidator.ts
@@ -280,6 +280,14 @@ export default class Liquidator {
         .estimateGas({
           gasLimit: Liquidator.GAS_LIMIT,
         });
+      if (process.env.SIM && estimatedGasLimit < 23000) {
+        return {
+          success: false,
+          estimatedGas: estimatedGasLimit,
+          error: LiquidationError.Unknown,
+          errorMsg: "Anvil doesn't bubble-up reverts when estimating gas, so we have no clue what's happening"
+        }
+      }
       return {
         success: true,
         estimatedGas: estimatedGasLimit,

--- a/app/src/TxManager.ts
+++ b/app/src/TxManager.ts
@@ -12,7 +12,6 @@ config();
 const MAX_RETRIES_ALLOWED: number = 10;
 const GAS_INCREASE_FACTOR: number = 1.10;
 const MAX_ACCEPTABLE_ERRORS = 10;
-const WALLET_ADDRESS = process.env.WALLET_ADDRESS!;
 
 type LiquidationTxInfo = {
     borrower: string;
@@ -57,6 +56,10 @@ export default class TXManager {
         this.account = account;
         this.baseEtherscanURL = Liquidator.getBaseEtherscanUrl(chainId);
         this.gasPriceMaximum = TXManager.getMaxGasPriceForChain(chainId);
+    }
+
+    public address() {
+        return this.account?.address;
     }
 
     public addLiquidatableAccount(address: string) {
@@ -108,8 +111,8 @@ export default class TXManager {
                 log("debug", `Exceeded maximum amount of retries when attempting to liquidate borrower: ${borrower}`);
                 continue;
             }
-            const encodedAddress = this.client.eth.abi.encodeParameter("address", WALLET_ADDRESS);
-            const currentNonce = await this.client.eth.getTransactionCount(WALLET_ADDRESS, "pending");
+            const encodedAddress = this.client.eth.abi.encodeParameter("address", this.account.address);
+            const currentNonce = await this.client.eth.getTransactionCount(this.account.address, "pending");
             const estimatedGasLimit: number = await this.liquidatorContract.methods
                 .liquidate(borrower, encodedAddress, liquidationTxInfo.currentStrain)
                 .estimateGas({
@@ -118,7 +121,7 @@ export default class TXManager {
             const updatedGasLimit = Math.ceil(estimatedGasLimit * GAS_INCREASE_FACTOR);
             const encodedData = this.liquidatorContract.methods.liquidate(borrower, encodedAddress, liquidationTxInfo.currentStrain).encodeABI();
             const transactionConfig: TransactionConfig = {
-                from: WALLET_ADDRESS,
+                from: this.account.address,
                 to: this.liquidatorContract.options.address,
                 gasPrice: liquidationTxInfo.gasPrice,
                 gas: updatedGasLimit,

--- a/app/src/index-sim.ts
+++ b/app/src/index-sim.ts
@@ -12,14 +12,14 @@ import {
 const alchemy_key = process.env.ALCHEMY_API_KEY;
 const anvil = startAnvil({
   forkUrl: `https://opt-mainnet.g.alchemy.com/v2/${alchemy_key}`,
-  forkBlockNumber: Number(process.argv[2]), // e.g. 79537361
+  forkBlockNumber: Number(process.argv[2]), // e.g. 92975261
   blockTime: 5,
   baseFee: 1,
 });
 
 nextStdoutMsg(anvil).then(async () => {
   // `await` this to make sure things are good to go
-  const web3 = await web3WithWebsocketProvider("ws://localhost:8545");
+  const web3 = await web3WithWebsocketProvider("ws://127.0.0.1:8545");
 
   // NOTE: We can do all the usual things with this `web3` instance, e.g.:
   /*

--- a/app/src/index-sim.ts
+++ b/app/src/index-sim.ts
@@ -1,0 +1,44 @@
+import { spawn } from "node:child_process";
+
+import dotenv from "dotenv";
+dotenv.config();
+
+import {
+  web3WithWebsocketProvider,
+  nextStdoutMsg,
+  startAnvil,
+} from "./sim/Utils";
+
+const alchemy_key = process.env.ALCHEMY_API_KEY;
+const anvil = startAnvil({
+  forkUrl: `https://opt-mainnet.g.alchemy.com/v2/${alchemy_key}`,
+  forkBlockNumber: Number(process.argv[2]), // e.g. 79537361
+  blockTime: 5,
+  baseFee: 1,
+});
+
+nextStdoutMsg(anvil).then(async () => {
+  // `await` this to make sure things are good to go
+  const web3 = await web3WithWebsocketProvider("ws://localhost:8545");
+
+  // NOTE: We can do all the usual things with this `web3` instance, e.g.:
+  /*
+  web3.eth.subscribe("newBlockHeaders", (err, res) => {
+    console.log(err, res);
+  });
+  process.on("SIGINT", () => {
+    web3.eth.clearSubscriptions(() => {});
+  });
+  */
+
+  const bot = spawn("node", ["lib/index.js"], {
+    cwd: process.cwd(),
+    env: { ...process.env, SIM: "true" },
+    stdio: "pipe",
+  });
+  bot.stdout.on("data", (data) => console.info(String(data)));
+  bot.stderr.on("data", (data) => console.error(String(data)));
+  process.on("beforeExit", () => {
+    bot.kill("SIGINT");
+  });
+});

--- a/app/src/index.ts
+++ b/app/src/index.ts
@@ -22,10 +22,12 @@ const limiter = new Bottleneck({
   minTime: MS_BETWEEN_REQUESTS,
 });
 const LIQUIDATOR_ADDRESS = process.env.LIQUIDATOR_ADDRESS!;
-const liquidators: Liquidator[] = [
-  new Liquidator(OPTIMISM_ALCHEMY_URL, LIQUIDATOR_ADDRESS, limiter),
-  new Liquidator(ARBITRUM_ALCHEMY_URL, LIQUIDATOR_ADDRESS, limiter),
-];
+const liquidators: Liquidator[] = process.env.SIM === 'true'
+  ? [new Liquidator("ws://localhost:8545", LIQUIDATOR_ADDRESS, limiter)]
+  : [
+      new Liquidator(OPTIMISM_ALCHEMY_URL, LIQUIDATOR_ADDRESS, limiter),
+      new Liquidator(ARBITRUM_ALCHEMY_URL, LIQUIDATOR_ADDRESS, limiter),
+    ];
 
 app.get("/liquidator_liveness_check", (req, res) => {
   res.status(STATUS_OK).send({ status: "ok" });

--- a/app/src/index.ts
+++ b/app/src/index.ts
@@ -23,7 +23,7 @@ const limiter = new Bottleneck({
 });
 const LIQUIDATOR_ADDRESS = process.env.LIQUIDATOR_ADDRESS!;
 const liquidators: Liquidator[] = process.env.SIM === 'true'
-  ? [new Liquidator("ws://localhost:8545", LIQUIDATOR_ADDRESS, limiter)]
+  ? [new Liquidator("ws://127.0.0.1:8545", LIQUIDATOR_ADDRESS, limiter)]
   : [
       new Liquidator(OPTIMISM_ALCHEMY_URL, LIQUIDATOR_ADDRESS, limiter),
       new Liquidator(ARBITRUM_ALCHEMY_URL, LIQUIDATOR_ADDRESS, limiter),

--- a/app/src/sim/Utils.ts
+++ b/app/src/sim/Utils.ts
@@ -1,0 +1,118 @@
+import { ChildProcessWithoutNullStreams, spawn } from "node:child_process";
+
+import Web3 from "web3";
+import winston from "winston";
+
+function createLogger(filename: string) {
+  return winston.createLogger({
+    level: "info",
+    format: winston.format.simple(),
+    transports: [
+      new winston.transports.File({
+        filename: filename,
+        level: "debug",
+      }),
+    ],
+    exitOnError: false,
+  });
+}
+
+export function sleep(ms: number) {
+  return new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+export function nextStdoutMsg(proc: ChildProcessWithoutNullStreams) {
+  return new Promise<void>((resolve) => {
+    proc.stdout.once("data", (_) => resolve());
+  });
+}
+
+export type AnvilOptions = {
+  /**
+   * RPC URL from which to pull real chain state
+   */
+  forkUrl?: string;
+  /**
+   * Block number at which to fork away from real RPC state
+   */
+  forkBlockNumber?: number;
+  /**
+   * Time between mined blocks in seconds, e.g. `2` would mean a fake block is mined every other second.
+   */
+  blockTime?: number;
+  /**
+   * Port on localhost for HTTP and WS providers. Default is 8545.
+   */
+  port?: number;
+  /**
+   * Path to IPC connection file, e.g. "./anvil.ipc". If unspecified, IPC provider is disabled.
+   */
+  ipc?: string;
+  /**
+   * Minimum fee charged for a transaction
+   */
+  baseFee?: number;
+};
+
+export function startAnvil(
+  options: AnvilOptions,
+  logging = true
+): ChildProcessWithoutNullStreams {
+  const argPairs = Object.entries(options);
+  const args: string[] = [];
+
+  for (const argPair of argPairs) {
+    // Split argPair[0] string at every capital letter
+    const name = argPair[0]
+      .split(/(?=[A-Z])/)
+      .map((s) => s.toLowerCase())
+      .join("-");
+    const value = String(argPair[1]);
+    args.push(`--${name}`, value);
+  }
+
+  console.info("\nStarting anvil with args:");
+  console.info(args);
+  console.info("");
+
+  const anvil = spawn("anvil", args, {
+    cwd: process.cwd(),
+    env: process.env,
+    stdio: "pipe",
+  });
+
+  process.on("beforeExit", () => {
+    anvil.kill("SIGINT");
+  });
+
+  if (logging) {
+    const logger = createLogger("anvil-debug.log");
+    anvil.stdout.on("data", (data) => logger.info(data));
+    anvil.stderr.on("data", (data) => logger.error(data));
+  }
+
+  return anvil;
+}
+
+export async function web3WithWebsocketProvider(
+  url: string,
+  connectionAttempts = 5
+) {
+  for (let i = 0; i < connectionAttempts; i += 1) {
+    try {
+      const provider = new Web3.providers.WebsocketProvider(url);
+      const web3 = new Web3(provider);
+
+      await web3.eth.getBlockNumber();
+      return web3;
+    } catch (e) {
+      console.error(e);
+      await sleep(100);
+    }
+  }
+  throw new Error(
+    `Couldn't connect to ${url} despite ${connectionAttempts} tries`
+  );
+}

--- a/app/src/sim/Utils.ts
+++ b/app/src/sim/Utils.ts
@@ -98,7 +98,7 @@ export function startAnvil(
 
 export async function web3WithWebsocketProvider(
   url: string,
-  connectionAttempts = 5
+  connectionAttempts = 10
 ) {
   for (let i = 0; i < connectionAttempts; i += 1) {
     try {
@@ -109,7 +109,7 @@ export async function web3WithWebsocketProvider(
       return web3;
     } catch (e) {
       console.error(e);
-      await sleep(100);
+      await sleep(1000);
     }
   }
   throw new Error(


### PR DESCRIPTION
This addition makes it possible to replay prior liquidations, at least ones that were triggered by interest accrual (as opposed to price change). Simply run `yarn sim <block_number>` where block number is set to be 1 block prior to the liquidation/warning in question.

This code can be adapted to create unit tests and/or extended to support simulation of liquidations caused by price change. For that we'll need to do `web3.eth.extend(...)` and use some of the special methods listed [here](https://book.getfoundry.sh/reference/anvil/#custom-methods).

I tested this using the block number in index-sim.ts, and borrower `0x73e662293453f7d019865362e47e4ce590322926` was in fact liquidated on the simulated chain.