### PR TITLE
Adding heartbeat and auto-reconnect

### DIFF
--- a/app/src/Liquidator.ts
+++ b/app/src/Liquidator.ts
@@ -1,4 +1,5 @@
 import Web3 from "web3";
+import { WebsocketProvider } from "web3-providers-ws";
 import { Log } from "web3-core";
 import { Contract } from "web3-eth-contract";
 import { AbiItem } from "web3-utils";
@@ -8,6 +9,7 @@ import TxManager from "./TxManager";
 import winston from "winston";
 import Bottleneck from "bottleneck";
 import * as Sentry from "@sentry/node";
+import { withTimeout } from "./Utils";
 
 const FACTORY_ADDRESS: string = process.env.FACTORY_ADDRESS!;
 const CREATE_ACCOUNT_TOPIC_ID: string = process.env.CREATE_ACCOUNT_TOPIC_ID!;
@@ -15,6 +17,8 @@ const WALLET_ADDRESS = process.env.WALLET_ADDRESS!;
 const ALOE_INITIAL_DEPLOY = 0;
 const POLLING_INTERVAL_MS = 150_000; // 2.5 minutes
 export const PROCESS_LIQUIDATABLE_INTERVAL_MS = 20_000; // 20 seconds
+const HEARTBEAT_INTERVAL_MS = 15_000; // 15 seconds
+const HEARTBEAT_TIMEOUT_MS = 10_000; // 10 seconds
 const CLIENT_KEEPALIVE_INTERVAL_MS = 60_000;
 const RECONNECT_DELAY_MS = 5_000;
 const RECONNECT_MAX_ATTEMPTS = 5;
@@ -46,6 +50,8 @@ export default class Liquidator {
   public static readonly GAS_LIMIT = 3_000_000;
   private pollingInterval: NodeJS.Timer | null;
   private processLiquidatableInterval: NodeJS.Timer | null;
+  private heartbeatInterval: NodeJS.Timer | null;
+  private provider: WebsocketProvider;
   private web3: Web3;
   private liquidatorContract: Contract;
   private txManager: TxManager;
@@ -67,7 +73,8 @@ export default class Liquidator {
   ) {
     this.pollingInterval = null;
     this.processLiquidatableInterval = null;
-    const provider = new Web3.providers.WebsocketProvider(jsonRpcURL, {
+    this.heartbeatInterval = null;
+    const wsProvider = new Web3.providers.WebsocketProvider(jsonRpcURL, {
       clientConfig: {
         keepalive: true,
         keepaliveInterval: CLIENT_KEEPALIVE_INTERVAL_MS,
@@ -79,7 +86,8 @@ export default class Liquidator {
         onTimeout: false,
       },
     });
-    this.web3 = new Web3(provider);
+    this.provider = wsProvider;
+    this.web3 = new Web3(wsProvider);
     this.web3.eth.handleRevert = true;
     this.liquidatorContract = new this.web3.eth.Contract(
       LiquidatorABIJson as AbiItem[],
@@ -108,6 +116,7 @@ export default class Liquidator {
     this.txManager.init(chainId);
 
     this.collectBorrowers(ALOE_INITIAL_DEPLOY);
+    this.startHeartbeat();
 
     this.pollingInterval = setInterval(() => {
       console.log(`#${this.uniqueId} Scanning borrowers on ${Liquidator.getChainName(chainId)}...`);
@@ -336,6 +345,27 @@ export default class Liquidator {
         errorMsg,
       };
     }
+  }
+
+  /**
+   * Starts the heartbeat interval.
+   * This is used to check if the provider is still connected.
+   * If the heartbeat fails, the provider will be reconnected.
+   */
+  private startHeartbeat(): void {
+    if (this.heartbeatInterval) {
+      winston.debug(`#${this.uniqueId} Heartbeat already started`);
+      return;
+    }
+    this.heartbeatInterval = setInterval(async () => {
+      try {
+        winston.debug(`#${this.uniqueId} ♥️ Heartbeat`);
+        await withTimeout(this.web3.eth.getChainId(), HEARTBEAT_TIMEOUT_MS);
+      } catch (e) {
+        Sentry.captureException(e);
+        this.provider.reconnect();
+      }
+    }, HEARTBEAT_INTERVAL_MS);
   }
 
   /**

--- a/app/src/Utils.ts
+++ b/app/src/Utils.ts
@@ -1,0 +1,10 @@
+export async function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<T>((_, reject) => {
+      setTimeout(() => {
+        reject(new Error(`Timed out in ${ms} ms.`));
+      }, ms);
+    }),
+  ]);
+}

--- a/app/src/index.ts
+++ b/app/src/index.ts
@@ -28,7 +28,7 @@ const liquidators: Liquidator[] = [
 
 Sentry.init({
   dsn: `https://${process.env.SENTRY_DSN0}@${process.env.SENTRY_DSN1}.ingest.sentry.io/${process.env.SENTRY_DSN2}`,
-  sampleRate: 0.1,
+  sampleRate: 0.2,
   enabled:
     process.env.SENTRY_DSN0 !== undefined &&
     process.env.SENTRY_DSN1 !== undefined &&

--- a/app/src/index.ts
+++ b/app/src/index.ts
@@ -29,7 +29,10 @@ const liquidators: Liquidator[] = [
 Sentry.init({
   dsn: `https://${process.env.SENTRY_DSN0}@${process.env.SENTRY_DSN1}.ingest.sentry.io/${process.env.SENTRY_DSN2}`,
   sampleRate: 0.1,
-  enabled: process.env.SENTRY_DSN0 !== undefined && process.env.SENTRY_DSN1 !== undefined && process.env.SENTRY_DSN2 !== undefined,
+  enabled:
+    process.env.SENTRY_DSN0 !== undefined &&
+    process.env.SENTRY_DSN1 !== undefined &&
+    process.env.SENTRY_DSN2 !== undefined,
   autoSessionTracking: false,
 });
 


### PR DESCRIPTION
In hopes of making the liquidator more resilient, I added a heartbeat interval to perform operations that do not cost us any credits regularly and check that it can still communicate and, if unable, auto-reconnect.