### PR TITLE
Use Sentry to capture gas estimation failure with richer context

### DIFF
--- a/app/src/Liquidator.ts
+++ b/app/src/Liquidator.ts
@@ -322,6 +322,16 @@ export default class Liquidator {
         estimatedGas: estimatedGasLimit,
       };
     } catch (e) {
+      const blockNumber = await this.web3.eth.getBlockNumber();
+      Sentry.captureException(e, scope => {
+        scope.setContext('parameters', {
+          'data': data,
+          'borrower': borrower,
+          'integerStrain': integerStrain,
+          'blockNumber': blockNumber,
+        })
+        return scope;
+      })
       const errorMsg = (e as Error).message;
       let errorType: LiquidationError = LiquidationError.Unknown;
       if (errorMsg.includes(LiquidationError.Healthy)) {


### PR DESCRIPTION
In order to track some of the errors that we encounter on the liquidator, we thought it'd be a good idea to add the `blockNumber` along with the parameters used when estimating the gas for a liquidation transaction. By including the block number and the relevant parameters for liquidation, we could re-run the same transactions and debug in `forge` or tenderly dev-nets.