### PR TITLE
Updating cloud build to add git commit sha to env

### DIFF
--- a/app/src/index.ts
+++ b/app/src/index.ts
@@ -34,6 +34,7 @@ Sentry.init({
     process.env.SENTRY_DSN1 !== undefined &&
     process.env.SENTRY_DSN2 !== undefined,
   autoSessionTracking: false,
+  release: process.env.GIT_COMMIT_SHA || undefined,
 });
 
 app.get("/liquidator_liveness_check", (req, res) => {

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -16,6 +16,7 @@ steps:
     - 'SENTRY_DSN0=${_SENTRY_DSN0}'
     - 'SENTRY_DSN1=${_SENTRY_DSN1}'
     - 'SENTRY_DSN2=${_SENTRY_DSN2}'
+    - 'GIT_COMMIT_SHA=$COMMIT_SHA'
 - name: 'gcr.io/cloud-builders/gcloud'
   dir: 'app'
   args: ['app', 'deploy', '.']


### PR DESCRIPTION
To utilize the releases, we have to initialize sentry with the corresponding git commit sha.