### PR TITLE
Decreasing sample rate for sentry

### DIFF
--- a/app/src/index.ts
+++ b/app/src/index.ts
@@ -28,7 +28,7 @@ const liquidators: Liquidator[] = [
 
 Sentry.init({
   dsn: `https://${process.env.SENTRY_DSN0}@${process.env.SENTRY_DSN1}.ingest.sentry.io/${process.env.SENTRY_DSN2}`,
-  sampleRate: 0.2,
+  sampleRate: 0.1,
   enabled:
     process.env.SENTRY_DSN0 !== undefined &&
     process.env.SENTRY_DSN1 !== undefined &&


### PR DESCRIPTION
Lots of non-crucial errors relating to alchemy are occurring, lowering the sample rate.