### PR TITLE
Adding a liquidator for base

### DIFF
--- a/app/src/Utils.ts
+++ b/app/src/Utils.ts
@@ -1,4 +1,9 @@
-export async function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+import axios from "axios";
+
+export async function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number
+): Promise<T> {
   return Promise.race([
     promise,
     new Promise<T>((_, reject) => {
@@ -7,4 +12,35 @@ export async function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T
       }, ms);
     }),
   ]);
+}
+
+export function getLogsBaseScan(
+  fromBlock: number,
+  address: string,
+  topics: (string | null)[],
+  shouldMatchAll: boolean,
+  pageLength = 1000,
+  page?: number,
+  toBlock?: number
+) {
+  let query = `https://api.basescan.org/api?module=logs&action=getLogs`.concat(
+    `&fromBlock=${fromBlock.toFixed(0)}`,
+    toBlock ? `&toBlock=${toBlock.toFixed(0)}` : "&toBlock=latest",
+    `&address=${address}`
+  );
+
+  for (let i = 0; i < topics.length; i += 1) {
+    if (topics[i] === null) continue;
+    query += `&topic${i}=${topics[i]}`;
+
+    if (i === topics.length - 1) break;
+    query += `&topic${i}_${i + 1}_opr=${shouldMatchAll ? "and" : "or"}`;
+  }
+
+  if (page) query += `&page=${page}`;
+  query += `&offset=${pageLength}`;
+  if (process.env.BASESCAN_API_KEY)
+    query += `&apikey=${process.env.BASESCAN_API_KEY}`;
+
+  return axios.get(query);
 }

--- a/app/src/index.ts
+++ b/app/src/index.ts
@@ -12,6 +12,7 @@ const OPTIMISM_ALCHEMY_URL = `wss://opt-mainnet.g.alchemy.com/v2/${process.env
   .ALCHEMY_API_KEY!}`;
 const ARBITRUM_ALCHEMY_URL = `wss://arb-mainnet.g.alchemy.com/v2/${process.env
   .ALCHEMY_API_KEY!}`;
+const BASE_ANKR_URL = `wss://rpc.ankr.com/base/ws/${process.env.ANKR_API_KEY!}`;
 const SLACK_WEBHOOK_URL = `https://hooks.slack.com/services/${process.env.SLACK_WEBHOOK0}/${process.env.SLACK_WEBHOOK1}/${process.env.SLACK_WEBHOOK2}`;
 const port = process.env.PORT || 8080;
 const app = express();
@@ -22,6 +23,7 @@ const limiter = new Bottleneck({
 });
 const LIQUIDATOR_ADDRESS = "0xe20fcDBC99fcfaCfEb319CC4536294Bd13d350A4";
 const liquidators: Liquidator[] = [
+  new Liquidator(BASE_ANKR_URL, LIQUIDATOR_ADDRESS, limiter),
   new Liquidator(OPTIMISM_ALCHEMY_URL, LIQUIDATOR_ADDRESS, limiter),
   new Liquidator(ARBITRUM_ALCHEMY_URL, LIQUIDATOR_ADDRESS, limiter),
 ];


### PR DESCRIPTION
This change requires slight modifications to the logic since there is still no excellent option for a node provider on base. In the meantime, we opted to use Basescan to scan past logs.